### PR TITLE
Add multi-dungeon progression to dungeon crawler

### DIFF
--- a/dungeon.bas
+++ b/dungeon.bas
@@ -2,11 +2,14 @@ option base 0
 randomize timer
 framebuffer create
 framebuffer write f
-const mw=30,mh=16
+const mw=30,mh=16,nd=3
 gold%=0
 hp%=100
 xp%=0
+dim base$(nd-1,mh-1)
 dim m$(mh-1)
+
+' Dungeon layouts
 data "##############################"
 data "#@                           #"
 data "#   #   #   #   #   #   #    #"
@@ -24,105 +27,187 @@ data "#  #    #    #    #    #     #"
 data "#                           X#"
 data "##############################"
 
-for i%=0 to mh-1:read m$(i%):next
+data "##############################"
+data "#@   ####      #             #"
+data "#    #  #      #   #######   #"
+data "#    #  ####   #        #    #"
+data "#    #      ####   ##   # ## #"
+data "#    ######       ##   ##    #"
+data "#           #######          #"
+data "#   ######## #     #######   #"
+data "#   #      # # ###       #   #"
+data "#   #  ##  #   #   ###   #   #"
+data "#   #   #      #   #     ##  #"
+data "#   ### ###### #   #  ####   #"
+data "#            # #          ## #"
+data "#   ######## # ##########    #"
+data "#             #            X #"
+data "##############################"
 
-' Gold placement
-for n%=1 to 4
-  do
-    x%=int(rnd*mw)
-    y%=int(rnd*mh)
-    c$=mid$(m$(y%),x%+1,1)
-  loop until c$=" "
-  m$(y%)=left$(m$(y%),x%)+"$"+                       mid$(m$(y%),x%+2)
+data "##############################"
+data "#@  #        ####      #     #"
+data "#   #  ####     #  ##  # ### #"
+data "#   ####  #  #  #  ##  # #   #"
+data "#        ##  #  #      # #   #"
+data "###### ####  ####  ####  #   #"
+data "#      #        #      # #   #"
+data "#  #######  ##  ###### # #   #"
+data "#      ##   ##         # #   #"
+data "#  ##   # ##### ###### # #   #"
+data "#  ##   #     # #      # #   #"
+data "#       ##### # #  ####  #   #"
+data "# ###        # #     #    #  #"
+data "# #   ######## # ### ######  #"
+data "# #                 #     X  #"
+data "##############################"
+
+for d%=0 to nd-1
+  for i%=0 to mh-1
+    read base$(d%,i%)
+  next
 next
 
-' Enemies placement
-for n%=1 to 2
-  do
-    x%=int(rnd*mw)
-    y%=int(rnd*mh)
-    c$=mid$(m$(y%),x%+1,1)
-  loop until c$=" "
-  m$(y%)=left$(m$(y%),x%)+"*"+       mid$(m$(y%),x%+2)
-next
+quit%=0
+dead%=0
+completed%=0
 
-for y%=0 to mh-1
-  p%=instr(1,m$(y%),"@")
-  if p%>0 then
-    px%=p%-1
-    py%=y%
-    mid$(m$(y%),p%,1)=" "
-    exit for
-  endif
-next
+for dungeon%=0 to nd-1
+  for i%=0 to mh-1
+    m$(i%)=base$(dungeon%,i%)
+  next
 
-do
+  ' Gold placement
+  for n%=1 to 4
+    do
+      x%=int(rnd*mw)
+      y%=int(rnd*mh)
+      c$=mid$(m$(y%),x%+1,1)
+    loop until c$=" "
+    m$(y%)=left$(m$(y%),x%)+"$"+mid$(m$(y%),x%+2)
+  next
+
+  ' Enemies placement
+  for n%=1 to 2
+    do
+      x%=int(rnd*mw)
+      y%=int(rnd*mh)
+      c$=mid$(m$(y%),x%+1,1)
+    loop until c$=" "
+    m$(y%)=left$(m$(y%),x%)+"*"+mid$(m$(y%),x%+2)
+  next
+
   for y%=0 to mh-1
-    if y%=py% then
-      r$=m$(y%)
-      mid$(r$,px%+1,1)="@"
-      ?r$
-    else
-      ?m$(y%)
+    p%=instr(1,m$(y%),"@")
+    if p%>0 then
+      px%=p%-1
+      py%=y%
+      mid$(m$(y%),p%,1)=" "
+      exit for
     endif
   next
-  ?""
-  ?"WASD - move"
-  ?"Q - quit"
-  ?"Gold: ";gold%
-  ?"HP: ";hp%
-  ?"XP: ";xp%
-  framebuffer copy f,n
-  cls
-  k$=""
+
+  exitFound%=0
+
   do
-    k$=ucase$(inkey$)
-  loop until k$<>""
-  nx%=px%
-  ny%=py%
-  if k$="W" then
-    ny%=py%-1
-  elseif k$="S" then
-    ny%=py%+1
-  elseif k$="A" then
-    nx%=px%-1
-  elseif k$="D" then
-    nx%=px%+1
-  elseif k$="Q" then
-    exit
-  endif
-  c$=mid$(m$(ny%),nx%+1,1)
-  if c$<>"#" then
-    px%=nx%
-    py%=ny%
-  endif
-  if c$="X" then
-    cls
-    ?"You got out!"
+    for y%=0 to mh-1
+      if y%=py% then
+        r$=m$(y%)
+        mid$(r$,px%+1,1)="@"
+        ?r$
+      else
+        ?m$(y%)
+      endif
+    next
+    ?""
+    ?"WASD - move"
+    ?"Q - quit"
     ?"Gold: ";gold%
     ?"HP: ";hp%
     ?"XP: ";xp%
     framebuffer copy f,n
-    exit
-  elseif c$="$" then
-    ' Found money
-    gold%=gold%+10
-    xp%=xp%+1
-    mid$(m$(ny%),nx%+1,1)=" "
-  elseif c$="*" then
-    ' Combat
-    gold%=gold%+int(rnd*100)
-    dmg%=5+int(rnd*6)
-    hp%=hp%-dmg%
-    xp%=xp%+15
-    mid$(m$(ny%),nx%+1,1)="."
-    if hp%<=0 then
+    cls
+    k$=""
+    do
+      k$=ucase$(inkey$)
+    loop until k$<>""
+    nx%=px%
+    ny%=py%
+    if k$="W" then
+      ny%=py%-1
+    elseif k$="S" then
+      ny%=py%+1
+    elseif k$="A" then
+      nx%=px%-1
+    elseif k$="D" then
+      nx%=px%+1
+    elseif k$="Q" then
       cls
-      ?"You succumbed to your      wounds!"
+      ?"You flee the dungeon."
       ?"Gold: ";gold%
+      ?"HP: ";hp%
       ?"XP: ";xp%
       framebuffer copy f,n
-      exit
+      quit%=1
+      exit do
+    endif
+    c$=mid$(m$(ny%),nx%+1,1)
+    if c$<>"#" then
+      px%=nx%
+      py%=ny%
+    endif
+    if c$="X" then
+      exitFound%=1
+      exit do
+    elseif c$="$" then
+      ' Found money
+      gold%=gold%+10
+      xp%=xp%+1
+      mid$(m$(ny%),nx%+1,1)=" "
+    elseif c$="*" then
+      ' Combat
+      gold%=gold%+int(rnd*100)
+      dmg%=5+int(rnd*6)
+      hp%=hp%-dmg%
+      xp%=xp%+15
+      mid$(m$(ny%),nx%+1,1)="."
+      if hp%<=0 then
+        cls
+        ?"You succumbed to your      wounds!"
+        ?"Gold: ";gold%
+        ?"XP: ";xp%
+        framebuffer copy f,n
+        dead%=1
+        exit do
+      endif
+    endif
+  loop
+
+  if dead% or quit% then exit for
+
+  if exitFound% then
+    if dungeon%=nd-1 then
+      cls
+      ?"You escaped every dungeon!"
+      ?"Gold: ";gold%
+      ?"HP: ";hp%
+      ?"XP: ";xp%
+      framebuffer copy f,n
+      completed%=1
+      exit for
+    else
+      cls
+      ?"Dungeon ";dungeon%+1;" cleared!"
+      ?"Prepare for dungeon ";dungeon%+2
+      framebuffer copy f,n
+      do
+        k$=inkey$
+      loop until k$<>""
     endif
   endif
-loop
+next
+
+if completed%=0 and quit%=0 and dead%=0 then
+  cls
+  ?"Your adventure ends early."
+  framebuffer copy f,n
+endif

--- a/dungeon.bas
+++ b/dungeon.bas
@@ -10,56 +10,56 @@ dim base$(nd-1,mh-1)
 dim m$(mh-1)
 
 ' Dungeon layouts
-data "##############################"
-data "#@                           #"
-data "#   #   #   #   #   #   #    #"
-data "#                            #"
-data "#  ### ########### ########  #"
-data "#   #   #   #   #   #   #    #"
-data "#   #   #   #   #   #   #    #"
-data "#  ### ########### ########  #"
-data "#                            #"
-data "#  #    #    #    #    #     #"
-data "#                            #"
-data "#  ### ##### ##### ##### ##  #"
-data "#                            #"
-data "#  #    #    #    #    #     #"
-data "#                           X#"
-data "##############################"
+data  "##############################"
+data "#@                            #"
+data "#   #   #   #   #   #   #     #"
+data "#                             #"
+data "#  ### ########### ########   #"
+data "#   #   #   #   #   #   #     #"
+data "#   #   #   #   #   #   #     #"
+data "#  ### ########### ########   #"
+data "#                             #"
+data "#  #    #    #    #    #      #"
+data "#                             #"
+data "#  ### ##### ##### ##### ##   #"
+data "#                             #"
+data "#  #    #    #    #    #      #"
+data "#                            X#"
+data  "##############################"
 
-data "##############################"
-data "#@   ####      #             #"
-data "#    #  #      #   #######   #"
-data "#    #  ####   #        #    #"
-data "#    #      ####   ##   # ## #"
-data "#    ######       ##   ##    #"
-data "#           #######          #"
-data "#   ######## #     #######   #"
-data "#   #      # # ###       #   #"
-data "#   #  ##  #   #   ###   #   #"
-data "#   #   #      #   #     ##  #"
-data "#   ### ###### #   #  ####   #"
-data "#            # #          ## #"
-data "#   ######## # ##########    #"
-data "#             #            X #"
-data "##############################"
+data  "##############################"
+data "#@   ####      #              #"
+data "#    #  #      #   #######    #"
+data "#    #  ####   #        #     #"
+data "#    #      ####   ##   # ##  #"
+data "#    ######       ##   ##     #"
+data "#           #######           #"
+data "#   ######## #     #######    #"
+data "#   #      # # ###       #    #"
+data "#   #  ##  #   #   ###   #    #"
+data "#   #   #      #   #     ##   #"
+data "#   ### ###### #   #  ####    #"
+data "#            # #          ##  #"
+data "#   ######## # ##########     #"
+data "#             #            X  #"
+data  "##############################"
 
-data "##############################"
-data "#@  #        ####      #     #"
-data "#   #  ####     #  ##  # ### #"
-data "#   ####  #  #  #  ##  # #   #"
-data "#        ##  #  #      # #   #"
-data "###### ####  ####  ####  #   #"
-data "#      #        #      # #   #"
-data "#  #######  ##  ###### # #   #"
-data "#      ##   ##         # #   #"
-data "#  ##   # ##### ###### # #   #"
-data "#  ##   #     # #      # #   #"
-data "#       ##### # #  ####  #   #"
-data "# ###        # #     #    #  #"
-data "# #   ######## # ### ######  #"
-data "# #                 #     X  #"
-data "##############################"
+data  "##############################"
+data "#@  #        ####      #      #"
+data "#   #  ####     #  ##  # ###  #"
+data "#   ####  #  #  #  ##    #    #"
+data "#        ##  #  #      # #    #"
+data "###### ####  ####  ####  #    #"
+data "#      #        #      # #    #"
+data "#  #######  ##  ###### # #    #"
+data "#      ##   ##         # #    #"
+data "#  ##   # ##### ###### #      #"
+data "#  ##   #     # #      # #    #"
+data "#       ##### # #  ####  #    #"
+data "# ###        #       #    #   #"
+data "# #   ######## ##### ######   #"
+data "# #                #      X   #"
+data  "##############################"
 
 for d%=0 to nd-1
   for i%=0 to mh-1
@@ -83,7 +83,7 @@ for dungeon%=0 to nd-1
       y%=int(rnd*mh)
       c$=mid$(m$(y%),x%+1,1)
     loop until c$=" "
-    m$(y%)=left$(m$(y%),x%)+"$"+mid$(m$(y%),x%+2)
+    m$(y%)=left$(m$(y%),  x%)+"$"+mid$(m$(y%),x%+2)
   next
 
   ' Enemies placement
@@ -93,7 +93,7 @@ for dungeon%=0 to nd-1
       y%=int(rnd*mh)
       c$=mid$(m$(y%),x%+1,1)
     loop until c$=" "
-    m$(y%)=left$(m$(y%),x%)+"*"+mid$(m$(y%),x%+2)
+    m$(y%)=left$(m$(y%),  x%)+"*"+mid$(m$(y%),x%+2)
   next
 
   for y%=0 to mh-1
@@ -172,7 +172,7 @@ for dungeon%=0 to nd-1
       mid$(m$(ny%),nx%+1,1)="."
       if hp%<=0 then
         cls
-        ?"You succumbed to your      wounds!"
+        ?"You succumbed to your        wounds!"
         ?"Gold: ";gold%
         ?"XP: ";xp%
         framebuffer copy f,n
@@ -196,17 +196,19 @@ for dungeon%=0 to nd-1
       exit for
     else
       cls
-      ?"Dungeon ";dungeon%+1;" cleared!"
-      ?"Prepare for dungeon ";dungeon%+2
+      ?"Dungeon ";dungeon%+1;"   cleared!"
+      ?"Prepare for dungeon   ";dungeon%+2
+      ?"[Enter] when ready"
       framebuffer copy f,n
       do
         k$=inkey$
       loop until k$<>""
+      cls
     endif
   endif
 next
 
-if completed%=0 and quit%=0 and dead%=0 then
+if completed%=0 and quit%=0 and   dead%=0 then
   cls
   ?"Your adventure ends early."
   framebuffer copy f,n


### PR DESCRIPTION
## Summary
- load three predefined dungeon layouts and iterate through them sequentially
- retain player state between levels while re-populating enemies and treasure
- add messaging for fleeing, death, dungeon transitions, and overall victory

## Testing
- not run (MMBasic program)


------
https://chatgpt.com/codex/tasks/task_e_68df8ac9a42c8321ad8c7b5bad8fed35